### PR TITLE
_isDead flag cancelled, remove channel when empty cancelled

### DIFF
--- a/Client.cpp
+++ b/Client.cpp
@@ -1,6 +1,6 @@
 #include "Client.hpp"
 
-Client::Client(int fd, std::string host, int port) : _fd(fd), _host(host), _port(port), _isAuth(false) {}
+Client::Client(int fd, std::string host, int port) : _fd(fd), _host(host), _port(port), _isAuth(false), _isDead(false) {}
 
 Client::~Client() {}
 

--- a/CommandQuit.cpp
+++ b/CommandQuit.cpp
@@ -12,7 +12,7 @@ void CommandQuit::execute(const std::string &args, Client *client)
 	
 	std::set<int> sharedMembersFd = Server::getInstance().getSharedMembersFd(client); // if NULL/
 	std::string msg = "QUIT :" + partMsg;
-	Server::getInstance().removeClient(client->get_fd());
+	// Server::getInstance().removeClient(client->get_fd());
 	Reply::sendBroadcast(sharedMembersFd, client, msg);
 	// client->set_isDead();
 	// check for leaks after this step

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ $(NAME):	$(OBJS)
 clean:
 	rm -f $(OBJ_DIR)/*.o $(DEPS)
 	rm -rf $(OBJ_DIR)
-# rm -f $(TEST_NAME)
 
 fclean:	clean
 	rm -f $(NAME)

--- a/Server.cpp
+++ b/Server.cpp
@@ -8,7 +8,10 @@ Server::~Server()
 	close(_fd);
 
 	for (size_t i = 0; i < _clientVec.size(); ++i)
+	{
+		// removeClient(_clientVec[i]->get_fd());
     	delete _clientVec[i];
+	}
 	_clientVec.clear();
 
 	std::vector<Channel*> channelsToDelete(_channelSet.begin(), _channelSet.end());
@@ -210,11 +213,14 @@ void Server::handleDataClient(int fd)
 {
 	for (size_t j = 0; j < _clientVec.size(); ++j)
 	{
+		// if (_clientVec[j] == NULL)
+		// 	continue;
 		if (_clientVec[j]->get_fd() == fd)
 		{
 			_clientVec[j]->parseDataClient();
-			if (_clientVec[j]->get_isDead())
-				Server::getInstance().removeClient(_clientVec[j]->get_fd());
+			// if (_clientVec[j]->get_isDead() == true)
+			// 	std::cout << "_clientVec[j]->get_isDead() == true" << std::endl;
+			// 	Server::getInstance().removeClient(_clientVec[j]->get_fd());
 			break;
 		}
 	}
@@ -245,11 +251,13 @@ void Server::removeClient(int fd)
 			for (std::set<Channel*>::iterator it = _channelSet.begin(); it != _channelSet.end(); ++it)
 			{
 				Channel* channel = *it;
+				if ((*it) == NULL)
+					continue;
 				channel->removeMember(client);
 				channel->removeInvite(client);
 				channel->removeOperator(client);
-				if (channel->get_memberSet().size() == 0)
-					removeChannel(channel);
+				// if (channel->get_memberSet().size() == 0)
+				// 	removeChannel(channel);
 			}
 			std::cout << "Client <" << client->get_fd() << ">" << " deleted.\n";
 			_poller->unregisterFd(fd);

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# Replace with your server's IP and port if needed
+HOST="127.0.0.1"
+PORT="6667"
+
+{
+  echo -ne "CAP LS\r\n"
+  sleep 0.2
+
+  echo -ne "PASS 1234\r\n"
+  sleep 0.2
+
+  echo -ne "NICK flo\r\n"
+  sleep 0.2
+
+  echo -ne "USER florencecousergue florencecousergue 127.0.0.1 :Florence Cousergue\r\n"
+  sleep 0.2
+
+  echo -ne "CAP END\r\n"
+  sleep 0.2
+
+  echo -ne "MODE flo +i\r\n"
+  sleep 0.2
+
+  echo -ne "PING Jean-Claude\r\n"
+  sleep 0.2
+
+  echo -ne "JOIN #test\r\n"
+  sleep 0.2
+
+  echo -ne "PRIVMSG #test :Hello from script!\r\n"
+  sleep 0.2
+
+  echo -ne "QUIT :bye\r\n"
+} | nc $HOST $PORT
+
+
+# # irc_test_invite_only
+# {
+#   echo -ne "PASS 1234\r\n"
+#   sleep 0.2
+#   echo -ne "NICK uninvited\r\n"
+#   sleep 0.2
+#   echo -ne "USER uninvited 0 * :Sneaky User\r\n"
+#   sleep 0.2
+#   echo -ne "JOIN #private\r\n"
+#   sleep 0.2
+#   echo -ne "QUIT :rejected\r\n"
+# } | nc 127.0.0.1 6667
+
+# # irc_test_join_and_privmsg
+# {
+#   echo -ne "PASS 1234\r\n"
+#   sleep 0.2
+#   echo -ne "NICK alice\r\n"
+#   sleep 0.2
+#   echo -ne "USER alice 0 * :Alice Test\r\n"
+#   sleep 0.2
+#   echo -ne "JOIN #test\r\n"
+#   sleep 0.2
+#   echo -ne "PRIVMSG #test :Hello from Alice!\r\n"
+#   sleep 0.2
+#   echo -ne "QUIT :bye\r\n"
+# } | nc 127.0.0.1 6667
+
+# # irc_test_kick
+# {
+#   echo -ne "PASS 1234\r\n"
+#   sleep 0.2
+#   echo -ne "NICK admin\r\n"
+#   sleep 0.2
+#   echo -ne "USER admin 0 * :Admin User\r\n"
+#   sleep 0.2
+#   echo -ne "JOIN #ops\r\n"
+#   sleep 0.2
+#   echo -ne "MODE #ops +o admin\r\n"
+#   sleep 0.2
+#   echo -ne "KICK #ops victim :testing kick\r\n"
+#   sleep 0.2
+#   echo -ne "QUIT :power down\r\n"
+# } | nc 127.0.0.1 6667
+
+# # irc_test_topic
+# {
+#   echo -ne "PASS 1234\r\n"
+#   sleep 0.2
+#   echo -ne "NICK topicuser\r\n"
+#   sleep 0.2
+#   echo -ne "USER topicuser 0 * :Topic Setter\r\n"
+#   sleep 0.2
+#   echo -ne "JOIN #test\r\n"
+#   sleep 0.2
+#   echo -ne "TOPIC #test :This is a scripted topic!\r\n"
+#   sleep 0.2
+#   echo -ne "QUIT :done\r\n"
+# } | nc 127.0.0.1 6667
+
+
+# # irc_test_unknown_command
+# {
+#   echo -ne "PASS 1234\r\n"
+#   sleep 0.2
+#   echo -ne "NICK glitch\r\n"
+#   sleep 0.2
+#   echo -ne "USER glitch 0 * :Curious User\r\n"
+#   sleep 0.2
+#   echo -ne "FOOBAR invalid command\r\n"
+#   sleep 0.2
+#   echo -ne "QUIT :testing done\r\n"
+# } | nc 127.0.0.1 6667


### PR DESCRIPTION
This pull request includes several changes to remedy leaks and testing in the server code. The most important changes include commenting out code related to client removal, and adding a new test script.

Changes to client handling:

* [`Server.cpp`](diffhunk://#diff-3fba487828186f23cf36e1c895829f4202d83a42f1dba18a227e886ce7754362R11-R14): Commented out code related to client removal in multiple functions, including `Server::~Server()`, `Server::handleDataClient(int fd)`, and `Server::removeClient(int fd)`. [[1]](diffhunk://#diff-3fba487828186f23cf36e1c895829f4202d83a42f1dba18a227e886ce7754362R11-R14) [[2]](diffhunk://#diff-3fba487828186f23cf36e1c895829f4202d83a42f1dba18a227e886ce7754362R216-R223) [[3]](diffhunk://#diff-3fba487828186f23cf36e1c895829f4202d83a42f1dba18a227e886ce7754362R254-R260)
* [`CommandQuit.cpp`](diffhunk://#diff-78e8b0eb45746ccd5d5d3012083350bf42876ab98a2189936b3d4051f082b4fcL15-R15): Commented out the line that removes a client from the server in the `CommandQuit::execute` method.

Testing improvements:

* [`test.sh`](diffhunk://#diff-3722d9ba8feb2d3feac8ce71a209a638d4b404e1c53f937188761181594023e2R1-R111): Added a new test script to automate testing of various IRC commands, such as `CAP LS`, `PASS`, `NICK`, `USER`, `JOIN`, `PRIVMSG`, and `QUIT`.